### PR TITLE
Add schema selection for Oracle databases

### DIFF
--- a/api/archive/source/list-schemas/lib/oracle.py
+++ b/api/archive/source/list-schemas/lib/oracle.py
@@ -1,0 +1,21 @@
+import oracledb
+
+
+def create_dsn(hostname: str, port: str, service: str) -> str:
+    return oracledb.makedsn(hostname, port, service_name=service)
+
+
+class Connection:
+    def __init__(self, hostname, port, username, password, database):
+        self.hostname = hostname
+        self.port = port
+        self.username = username
+        self.password = password
+        self.database = database
+
+    def list_schemas(self):
+        dsn = create_dsn(self.hostname, self.port, self.database)
+        with oracledb.connect(user=self.username, password=self.password, dsn=dsn) as conn:
+            with conn.cursor() as cursor:
+                cursor.execute("SELECT USERNAME FROM ALL_USERS")
+                return [row[0] for row in cursor.fetchall()]

--- a/api/archive/source/list-schemas/main.py
+++ b/api/archive/source/list-schemas/main.py
@@ -1,0 +1,55 @@
+import json
+import logging
+import os
+import traceback
+from lib import oracle
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO")
+logger = logging.getLogger()
+if logger.hasHandlers():
+    logger.setLevel(LOG_LEVEL)
+else:
+    logging.basicConfig(level=LOG_LEVEL)
+
+def mask_sensitive_data(event):
+    keys_to_redact = ["authorization"]
+    result = {}
+    for k, v in event.items():
+        if isinstance(v, dict):
+            result[k] = mask_sensitive_data(v)
+        elif k in keys_to_redact:
+            result[k] = "<redacted>"
+        else:
+            result[k] = v
+    return result
+
+def build_response(code, body):
+    return {
+        "headers": {
+            "Cache-Control": "no-cache, no-store",
+            "Content-Type": "application/json",
+        },
+        "statusCode": code,
+        "body": body,
+    }
+
+def lambda_handler(event, context):
+    logger.info(mask_sensitive_data(event))
+    body = json.loads(event.get("body", "{}"))
+
+    hostname = body.get("hostname")
+    port = body.get("port")
+    username = body.get("username")
+    password = body.get("password")
+    database = body.get("database")
+    engine = body.get("database_engine")
+
+    if engine != "oracle":
+        return build_response(400, json.dumps({"error": "Unsupported engine"}))
+    try:
+        conn = oracle.Connection(hostname, port, username, password, database)
+        schemas = conn.list_schemas()
+        return build_response(200, json.dumps({"schemas": schemas}))
+    except Exception:
+        logger.error(traceback.format_exc())
+        return build_response(500, "Server Error")

--- a/api/archive/source/list-schemas/requirements.txt
+++ b/api/archive/source/list-schemas/requirements.txt
@@ -1,0 +1,3 @@
+pymysql
+pymssql
+oracledb

--- a/api/archive/source/test-connection/lib/oracle.py
+++ b/api/archive/source/test-connection/lib/oracle.py
@@ -22,29 +22,22 @@ def create_dsn(hostname: str, port: str, service: str) -> str:
 
 
 class Connection:
-    def __init__(self, hostname, port, username, password, database, oracle_owner):
+    def __init__(self, hostname, port, username, password, database):
         self.hostname = hostname
         self.port = port
         self.username = username
         self.password = password
         self.database = database
-        self.oracle_owner = oracle_owner
 
     def testConnection(self):
-
         try:
-
             dsn = create_dsn(self.hostname, self.port, self.database)
             with oracledb.connect(user=self.username, password=self.password, dsn=dsn) as connection:
                 with connection.cursor() as cursor:
-                    sql = """SELECT owner, table_name  FROM all_tables WHERE OWNER = 'DMS_SAMPLE'"""
-                    for r in cursor.execute(sql):
-                        print(r)
-
-            # cursor.close()
+                    cursor.execute("SELECT 1 FROM dual")
+                    cursor.fetchall()
 
             return True
 
-        except Exception as e:
-            print(e)
+        except Exception:
             return False

--- a/api/archive/source/test-connection/main.py
+++ b/api/archive/source/test-connection/main.py
@@ -86,22 +86,20 @@ def lambda_handler(event, context):
             return build_response(500, "Server Error")
 
     elif database_engine == "oracle":
-        oracle_owner = body["oracle_owner"]
-        oracle_owner_list = oracle_owner.split(",")
-        for owner in oracle_owner_list:
-            try:
-                oracle_connection = oracle.Connection(hostname,
-                                                    port,
-                                                    username,
-                                                    password,
-                                                    database,
-                                                    owner)
-                connected = oracle_connection.testConnection()
-                response = {"connected": connected}
-                return build_response(200, json.dumps(response))
-            except Exception as ex:
-                logger.error(traceback.format_exc())
-                return build_response(500, "Server Error")
+        try:
+            oracle_connection = oracle.Connection(
+                hostname,
+                port,
+                username,
+                password,
+                database,
+            )
+            connected = oracle_connection.testConnection()
+            response = {"connected": connected}
+            return build_response(200, json.dumps(response))
+        except Exception as ex:
+            logger.error(traceback.format_exc())
+            return build_response(500, "Server Error")
             
     elif database_engine == "mssql":
         print("mssql")

--- a/deploy/src/app-stack.ts
+++ b/deploy/src/app-stack.ts
@@ -681,6 +681,33 @@ export class AppStack extends cdk.Stack {
             }
         );
 
+        const listSchemasLambda = new lambdaPython.PythonFunction(
+            this,
+            "ListSchemasFn",
+            {
+                role: databaseSchemaRole,
+                vpc: vpc,
+                securityGroups: [rdsSecurityGroup],
+                vpcSubnets: {
+                    subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+                },
+                allowPublicSubnet: true,
+                runtime: cdk.aws_lambda.Runtime.PYTHON_3_9,
+                handler: "lambda_handler",
+                index: "main.py",
+                entry: "../api/archive/source/list-schemas",
+                timeout: cdk.Duration.seconds(30),
+                environment: {},
+            }
+        );
+
+        new ApiGatewayV2LambdaConstruct(this, "ListSchemasApiGateway", {
+            lambdaFn: listSchemasLambda,
+            routePath: "/api/archive/source/list-schemas",
+            methods: [apigwv2.HttpMethod.POST],
+            api: api.apiGatewayV2,
+        });
+
         new ApiGatewayV2LambdaConstruct(this, "DatabaseSchema" + "ApiGateway", {
             lambdaFn: this.databaseSchemaLambda,
             routePath: "/api/archive/source/get-schema",

--- a/web-app/src/pages/AddArchive/FormContent.jsx
+++ b/web-app/src/pages/AddArchive/FormContent.jsx
@@ -80,6 +80,8 @@ export function FormContent({
     const [databaseEngine, setDatabaseEngine] = useState();
     const [databaseConnected, setDatabaseConnected] = useState(false);
     const [getTables, setGetTables] = useState(false);
+    const [schemaOptions, setSchemaOptions] = useState([]);
+    const [selectedSchemas, setSelectedSchemas] = useState([]);
 
     return (
         <BaseFormContent
@@ -100,6 +102,10 @@ export function FormContent({
                         setDatabaseConnected={setDatabaseConnected}
                         setFlashbarItems={setFlashbarItems}
                         setEnableFlashbar={setEnableFlashbar}
+                        schemaOptions={schemaOptions}
+                        setSchemaOptions={setSchemaOptions}
+                        selectedSchemas={selectedSchemas}
+                        setSelectedSchemas={setSelectedSchemas}
                     />
                     <TableDetailsPanel
                         databaseConnectionState={databaseConnectionState}
@@ -107,6 +113,7 @@ export function FormContent({
                         databaseConnected={databaseConnected}
                         setDatabaseConnected={setDatabaseConnected}
                         setGetTables={setGetTables}
+                        selectedSchemas={selectedSchemas}
                     />
                 </SpaceBetween>
             }


### PR DESCRIPTION
## Summary
- add new `list-schemas` API to read Oracle schemas
- test connection for Oracle without requiring an owner
- expose new endpoint in the CDK stack
- allow selecting Oracle schemas via multiselect
- enable table selection and send selected tables to the backend

## Testing
- `npm test --silent --prefix web-app` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851433e5c748326b2b90e024086c168