### PR TITLE
Fix S3 bucket deployments with ACLs

### DIFF
--- a/deploy/src/constructs/cloudfront-s3-website-construct.ts
+++ b/deploy/src/constructs/cloudfront-s3-website-construct.ts
@@ -67,6 +67,7 @@ export class CloudFrontS3WebSiteConstruct extends Construct {
 
     const siteBucket = new cdk.aws_s3.Bucket(this, "WebApp", {
       encryption: cdk.aws_s3.BucketEncryption.S3_MANAGED,
+      objectOwnership: cdk.aws_s3.ObjectOwnership.OBJECT_WRITER,
       autoDeleteObjects: true,
       blockPublicAccess: cdk.aws_s3.BlockPublicAccess.BLOCK_ALL,
       removalPolicy: cdk.RemovalPolicy.DESTROY,
@@ -75,6 +76,7 @@ export class CloudFrontS3WebSiteConstruct extends Construct {
         "WebAppServerAccessLogs",
         {
           encryption: cdk.aws_s3.BucketEncryption.S3_MANAGED,
+          objectOwnership: cdk.aws_s3.ObjectOwnership.OBJECT_WRITER,
           autoDeleteObjects: true,
           blockPublicAccess: cdk.aws_s3.BlockPublicAccess.BLOCK_ALL,
           removalPolicy: cdk.RemovalPolicy.DESTROY,

--- a/deploy/src/constructs/s3-bucket-construct.ts
+++ b/deploy/src/constructs/s3-bucket-construct.ts
@@ -83,6 +83,7 @@ export class S3BucketConstruct extends Construct {
       removalPolicy: props.removalPolicy,
       blockPublicAccess: props.blockPublicAccess,
       encryption: props.encryption,
+      objectOwnership: s3.ObjectOwnership.OBJECT_WRITER,
       serverAccessLogsPrefix: props.serverAccessLogsPrefix,
       versioned: props.versioned,
       autoDeleteObjects: props.deleteObjects,


### PR DESCRIPTION
## Summary
- allow ACLs on buckets created for CloudFront website deployment
- allow ACLs on generic S3 buckets used across the stack

## Testing
- `npm test -- --passWithNoTests` *(fails: `jest: not found`)*
- `npm install`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68526e3d10bc832680c65b408866ae69