### PR TITLE
Fix Ace config type error

### DIFF
--- a/web-app/src/pages/ViewArchive/ViewDataAccess.tsx
+++ b/web-app/src/pages/ViewArchive/ViewDataAccess.tsx
@@ -243,7 +243,6 @@ export function ViewData(
                     .then(() => {
                         ace.config.set("useStrictCSP", true);
                         ace.config.set("loadWorkerFromBlob", false);
-                        ace.config.set("readOnly", false);
                         ace.config.set("maxLines", 0);
                         setAce(ace);
                         setAceLoading(false);

--- a/web-app/src/pages/ViewArchive/ViewValidation.tsx
+++ b/web-app/src/pages/ViewArchive/ViewValidation.tsx
@@ -181,7 +181,6 @@ export function ValidationTable(
                     .then(() => {
                         ace.config.set("useStrictCSP", true);
                         ace.config.set("loadWorkerFromBlob", false);
-                        ace.config.set("readOnly", true);
                         ace.config.set("maxLines", 0);
 
                         // ace.config.set('basePath', '/app/');


### PR DESCRIPTION
## Summary
- remove invalid `readOnly` config usage

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `npm run lint --silent` *(fails: cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_685683cd9c34832693239e57a5940911