### PR TITLE
Fix Ace config option

### DIFF
--- a/web-app/src/pages/ViewArchive/ViewDataAccess.tsx
+++ b/web-app/src/pages/ViewArchive/ViewDataAccess.tsx
@@ -243,7 +243,6 @@ export function ViewData(
                     .then(() => {
                         ace.config.set("useStrictCSP", true);
                         ace.config.set("loadWorkerFromBlob", false);
-                        ace.config.set("maxLines", 0);
                         setAce(ace);
                         setAceLoading(false);
                     })

--- a/web-app/src/pages/ViewArchive/ViewValidation.tsx
+++ b/web-app/src/pages/ViewArchive/ViewValidation.tsx
@@ -181,7 +181,6 @@ export function ValidationTable(
                     .then(() => {
                         ace.config.set("useStrictCSP", true);
                         ace.config.set("loadWorkerFromBlob", false);
-                        ace.config.set("maxLines", 0);
 
                         // ace.config.set('basePath', '/app/');
                         setAce(ace);


### PR DESCRIPTION
## Summary
- remove unsupported `maxLines` option from Ace configuration

## Testing
- `npx tsc -p web-app/tsconfig.json --noEmit` *(fails: Option 'suppressImplicitAnyIndexErrors' has been removed)*

------
https://chatgpt.com/codex/tasks/task_e_6856872f332c83268955a17c001736d3